### PR TITLE
Add "Fairy Tail (2018)"

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2018-10-05
+- last_modified: 2018-10-07
 
 ::rules
 
@@ -252,6 +252,8 @@
 
 # Fairy Tail -> ~ (2014)
 - 6702|4676|6702:176-277 -> 22043|8203|20626:1-102!
+# Fairy Tail -> ~ (2018)
+- 6702|4676|6702:278-? -> 35972|13658|99749:1-?!
 
 # Fate/stay night: Unlimited Blade Works (TV) -> ~ Episode 0
 - 22297|7882|?:0 -> 27821|9718|?:1


### PR DESCRIPTION
~@erengy, is there a way to embed a synonym here?
Specifically, "Fairy Tail Final Season".~

Turns out this synonym is already a part of the anime info on AniList but for some reason Taiga doesn't know about it - and can't associate the torrents - unless I add the anime into my list. I guess this limitation is unavoidable.