### PR TITLE
Fairy Tail Final Season

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -267,8 +267,8 @@
 - 6702|4676|6702:176-277 -> 22043|8203|20626:1-102!
 # Fairy Tail -> ~ (2018)
 - 6702|4676|6702:278-? -> 35972|13658|99749:1-?!
-# Fairy Tail Final Season  -> ~
-- 35972|13658|99749:278-? -> ~|~|~:1-?!
+# Fairy Tail Final Season  -> Fairy Tail: Final Series
+- 35972|13658|99749:278-? -> ~|~|~:1-?
 
 # Fate/stay night: Unlimited Blade Works (TV) -> ~ Episode 0
 - 22297|7882|?:0 -> 27821|9718|?:1

--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2019-04-28
+- last_modified: 2019-04-29
 
 ::rules
 
@@ -267,6 +267,8 @@
 - 6702|4676|6702:176-277 -> 22043|8203|20626:1-102!
 # Fairy Tail -> ~ (2018)
 - 6702|4676|6702:278-? -> 35972|13658|99749:1-?!
+# Fairy Tail Final Season  -> ~
+- 35972|13658|99749:278-? -> ~|~|~:1-?!
 
 # Fate/stay night: Unlimited Blade Works (TV) -> ~ Episode 0
 - 22297|7882|?:0 -> 27821|9718|?:1


### PR DESCRIPTION
Fairy Tail Final Season can use the same numbering as Fairy Tail causing a mixup.  This fixes it.