### PR TITLE
Add "Watashi ni Tenshi ga Maiorita! Special" and "Lord El-Melloi II-sei no Jikenbo: "Rail Zeppelin" Grace note - Hakamori to Neko to Majutsu-shi"

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2019-04-28
+- last_modified: 2019-07-08
 
 ::rules
 
@@ -494,6 +494,9 @@
 
 # Log Horizon -> ~ 2
 - 17265|7622|17265:26-50 -> 23321|8313|20671:1-25!
+
+# Lord El-Melloi II-sei no Jikenbo: "Rail Zeppelin" Grace note -> ~ - Hakamori to Neko to Majutsu-shi
+- 38959|42092|106918:0 -> 38936|42076|106862:1
 
 # Love Hina -> ~: Motoko's Choice, Love or the Sword - Don't Cry
 - 189|166|189:25 -> 963|853|963:1


### PR DESCRIPTION
HorribleSubs for both series.

One thing to note is that for Lord El-Melloi II Case Files, Taiga doesn't immediately match the title with the series since the name of the series on AniList is "Lord El-Melloi II's Case Files {Rail Zeppelin} Grace note" so I'm not sure how that's fixed.