### PR TITLE
Add mapping for Build Divide: Code White

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -388,7 +388,7 @@
 # Gurazeni -> ~ 2
 - 35183|13981|98479:13-24 -> 37990|41948|102974:1-12!
 
-# Hachigatsu no Cinderella Nine -> ~: Tsudzuku, Monogatari 
+# Hachigatsu no Cinderella Nine -> ~: Tsudzuku, Monogatari
 - 38091|42144|104989:13 -> 49913|45268|139813:1
 
 # Hagure Yuusha no Aesthetica: Hajirai Ippai -> Queen's Blade Rebellion vs. Hagure Yuusha no Aesthetica

--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2022-04-13
+- last_modified: 2022-04-28
 
 ::rules
 
@@ -164,6 +164,9 @@
 
 # Bubuki Buranki -> ~: Hoshi no Kyojin
 - 32023|11486|21471:13-24 -> 33041|12004|21740:1-12
+
+# Build Divide: Code Black -> ~: Code White
+- 48776|44425|132525:13-24 -> 48777|44426|132526:1-12!
 
 # Bungou Stray Dogs -> ~ 2nd Season
 - 31478|11339|21311:13-24 -> 32867|11882|21679:1-12!


### PR DESCRIPTION
… which is the second season of \~: Code Black. Crunchyroll simply continues their numbering [1] and kitsu even calls it "\~: Code Black 2nd Season" [2].

(Also note how the page title of the CR page actually uses "code white".)

[1]: https://www.crunchyroll.com/de/build-divide-000000-code-black/episode-13-no-rain-no-rainbow-821151
[2]: https://kitsu.io/anime/build-divide-code-black-2nd-season