### PR TITLE
Add "Shuumatsu no Valkyrie II Part 2"

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2023-07-08
+- last_modified: 2023-07-13
 
 ::rules
 
@@ -946,6 +946,9 @@
 
 # Shugo Chara! -> ~! Doki
 - 2923|2648|2923:52-102 -> 5262|4019|5262:1-51!
+
+# Shuumatsu no Valkyrie II -> ~ Part 2
+- 49618|44988|138056:11-15 -> 55454|47495|165356:1-5!
 
 # So Ra No Wo To -> ~ Specials
 - 6802|7668|6802:13 -> 8197|4724|8197:2


### PR DESCRIPTION
Netflix puts both parts of Season 2 on the same season, unlike AL, MAL and Kitsu.