### PR TITLE
Add Bleach: Sennen Kessen-hen - Soukoku-tan [Anime Time]

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2024-10-04
+- last_modified: 2024-10-05
 
 ::rules
 
@@ -149,6 +149,8 @@
 
 # Bleach: Sennen Kessen-hen -> ~ - Ketsubetsu-tan
 - 41467|43078|116674:14-26 -> 53998|46903|159322:1-13!
+# Bleach: Sennen Kessen-hen -> ~ - Soukoku-tan
+- 41467|43078|116674:27-? -> 56784|48015|169755:1-?!
 
 # Boku no Hero Academia -> ~ 2nd Season
 - 31964|11469|21459:14-38 -> 33486|12268|21856:1-25


### PR DESCRIPTION
Redirect 'Bleach: Sennen Kessen-hen' EP27+ to 'Bleach: Sennen Kessen-hen - Soukoku-tan'
Fansub group: Anime Time

ToonsHub uses "BLEACH Thousand-Year Blood War S03E01" naming instead. In the Torrents tab Taiga correctly parses the title as "BLEACH: Thousand-Year Blood War Season 3", but still can't seem to link it with the entry in my anime list. Meanwhile in the torrent the actual file name has S03S27 in the name...
I have no idea what to do about this, if there even is anything that can be done.