### PR TITLE
Added episode count to Solo Leveling Season 2

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2025-01-04
+- last_modified: 2025-01-07
 
 ::rules
 
@@ -857,7 +857,7 @@
 - 5341|4063|5341:0 -> 6007|4382|6007:1
 
 # Ore dake Level Up na Ken -> ~: Season 2
-- 52299|46231|151807:13-? -> 58567|48671|176496:1-12
+- 52299|46231|151807:13-25 -> 58567|48671|176496:1-12
 
 # Ore no Imouto ga Konnani Kawaii Wake ga Nai -> ~ Specials
 - 8769|5487|8769:13-15 -> 10020|5998|10020:2-4


### PR DESCRIPTION
#182  Episode count has been confirmed to be 13, so updated the rule.