### PR TITLE
Add redirect for Sorairo Utility

### DIFF
--- a/anime-relations.txt
+++ b/anime-relations.txt
@@ -35,7 +35,7 @@
 - version: 1.3.0
 
 # Update this date when you add, remove or modify a rule.
-- last_modified: 2025-01-23
+- last_modified: 2025-01-25
 
 ::rules
 
@@ -946,7 +946,7 @@
 # Rurouni Kenshin: Meiji Kenkaku Romantan -> ~ Special
 - 45|27|45:95 -> 12067|6659|12067:1
 
-# Rurouni Kenshin: Meiji Kenkaku Romantan (2023) -> ~ Kyoto Douran 
+# Rurouni Kenshin: Meiji Kenkaku Romantan (2023) -> ~ Kyoto Douran
 - 50613|45616|142877:25-47 -> 57554|48393|171637:1-23!
 
 # Saenai Heroine no Sodatekata -> ~: Ai to Seishun no Service Kai
@@ -1062,6 +1062,9 @@
 
 # So Ra No Wo To -> ~ Specials
 - 6802|7668|6802:13 -> 8197|4724|8197:2
+
+# Sorairo Utility -> ~ (TV)
+- 50209|45365|140700:2-12 -> 58066|48532|174596:2-12
 
 # Soukyuu no Fafner: Dead Aggressor - Exodus -> ~ 2nd Season
 - 17080|7575|17080:14-26 -> 30549|10854|21287:1-13!


### PR DESCRIPTION
The TV series from 2025 has the same name as the OVA of 2021 and is disambiguated by a "(TV)" suffix sometimes, but this is unreliable and its is much more likely that the series is accidentally recognized as the OVA. Since the OVA only has one episode, we can redirect all other episodes to the TV series.