### PR TITLE
Auto-update the `last_modified` line

### DIFF
--- a/.github/workflows/update-last-modified.yml
+++ b/.github/workflows/update-last-modified.yml
@@ -1,0 +1,18 @@
+name: Update Last Modified Date
+on:
+  push:
+    branches: ['master']
+jobs:
+  generate-lists:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Replace last_modified line
+        run: |
+          sed -i -r -e "s/^- last_modified: [-0-9]{10}$/- last_modified: $(date '+%Y-%m-%d')/" anime-relations.txt
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Update `last_modified`
+          commit_author: Github Actions <actions@github.com>

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ By appending an `!` to the rule, we also handled the cases such as `Fate Zero S2
 
 1. Look up MyAnimeList, Kitsu and AniList IDs of both anime.
 2. Create a new rule and place it in alphabetical order, using the main title from MyAnimeList.
-3. Update the `last_modified` date in `YYYY-MM-DD` format.
-4. Make sure the rule is working, by testing it before sending a pull request.
-5. In the pull request description, indicate which fansub groups' releases require the new rule.
+3. Make sure the rule is working, by testing it before sending a pull request.
+4. In the pull request description, indicate which fansub groups' releases require the new rule.
 
 ## License
 


### PR DESCRIPTION
Avoid merge conflicts by having a GitHub Action automatically update the `last_updated` line/field on merge.